### PR TITLE
Added support for octets and alternate filename format

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -77,7 +77,6 @@ func ParseMIMEBody(mailMsg *mail.Message) (*MIMEBody, error) {
 		if boundary == "" {
 			return nil, fmt.Errorf("Unable to locate boundary param in Content-Type header")
 		}
-
 		// Root Node of our tree
 		root := NewMIMEPart(nil, mediatype)
 		mimeMsg.Root = root
@@ -117,7 +116,7 @@ func ParseMIMEBody(mailMsg *mail.Message) (*MIMEBody, error) {
 
 		// Locate attachments
 		mimeMsg.Attachments = BreadthMatchAll(root, func(p MIMEPart) bool {
-			return p.Disposition() == "attachment"
+			return p.Disposition() == "attachment" || p.ContentType() == "application/octet-stream"
 		})
 
 		// Locate inlines

--- a/part.go
+++ b/part.go
@@ -182,6 +182,9 @@ func parseParts(parent *memMIMEPart, reader io.Reader, boundary string) error {
 		if p.fileName == "" && mparams["name"] != "" {
 			p.fileName = mparams["name"]
 		}
+		if p.fileName == "" && mparams["file"] != "" {
+			p.fileName = mparams["file"]
+		}
 
 		boundary := mparams["boundary"]
 		if boundary != "" {


### PR DESCRIPTION
Added support for a non-standard attachment format.  It seems that RFC2183 isn't used as often we'd like in the wild.