### PR TITLE
Let's expose decodeHeader function

### DIFF
--- a/header.go
+++ b/header.go
@@ -97,7 +97,7 @@ func (h *headerDec) accept(valid string) bool {
 }
 
 // Decode a MIME header per RFC 2047
-func decodeHeader(input string) string {
+func DecodeHeader(input string) string {
 	if !strings.Contains(input, "=?") {
 		// Don't scan if there is nothing to do here
 		return input

--- a/header_test.go
+++ b/header_test.go
@@ -50,7 +50,7 @@ func TestBase64Decoder(t *testing.T) {
 func TestPlainSingleToken(t *testing.T) {
 	input := "Test"
 	expect := input
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -58,7 +58,7 @@ func TestPlainSingleToken(t *testing.T) {
 func TestPlainTokens(t *testing.T) {
 	input := "Testing One two 3 4"
 	expect := input
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -66,7 +66,7 @@ func TestPlainTokens(t *testing.T) {
 func TestCharsetControlDetect(t *testing.T) {
 	input := "=?US\nASCII?Q?Keith_Moore?="
 	expect := input
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -74,7 +74,7 @@ func TestCharsetControlDetect(t *testing.T) {
 func TestEncodingControlDetect(t *testing.T) {
 	input := "=?US-ASCII?\r?Keith_Moore?="
 	expect := input
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -82,7 +82,7 @@ func TestEncodingControlDetect(t *testing.T) {
 func TestEncTextControlDetect(t *testing.T) {
 	input := "=?US-ASCII?Q?Keith\tMoore?="
 	expect := input
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -90,7 +90,7 @@ func TestEncTextControlDetect(t *testing.T) {
 func TestInvalidTermination(t *testing.T) {
 	input := "=?US-ASCII?Q?Keith_Moore?!"
 	expect := input
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -98,7 +98,7 @@ func TestInvalidTermination(t *testing.T) {
 func TestAsciiQ(t *testing.T) {
 	input := "=?US-ASCII?Q?Keith_Moore?="
 	expect := "Keith Moore"
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -106,7 +106,7 @@ func TestAsciiQ(t *testing.T) {
 func TestAsciiB64(t *testing.T) {
 	input := "=?US-ASCII?B?SGVsbG8gV29ybGQ=?="
 	expect := "Hello World"
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -115,13 +115,13 @@ func TestEmbeddedAsciiQ(t *testing.T) {
 	// This is not legal, so we expect it to fail
 	input := "ab=?US-ASCII?Q?Keith_Moore?=CD"
 	expect := input
-	result := decodeHeader(input)
+	result := DecodeHeader(input)
 	assert.Equal(t, expect, result)
 
 	// Abutting a MIME header comment is legal
 	input = "(=?US-ASCII?Q?Keith_Moore?=)"
 	expect = "(Keith Moore)"
-	result = decodeHeader(input)
+	result = DecodeHeader(input)
 	assert.Equal(t, expect, result)
 }
 
@@ -140,7 +140,7 @@ func TestSpacing(t *testing.T) {
 	}
 
 	for _, tt := range testTable {
-		result := decodeHeader(tt.input)
+		result := DecodeHeader(tt.input)
 		assert.Equal(t, tt.expect, result,
 			"Expected %q, got %q for input %q", tt.expect, result, tt.input)
 	}
@@ -157,7 +157,7 @@ func TestCharsets(t *testing.T) {
 	}
 
 	for _, tt := range testTable {
-		result := decodeHeader(tt.input)
+		result := DecodeHeader(tt.input)
 		assert.Equal(t, tt.expect, result,
 			"Expected %q, got %q for input %q", tt.expect, result, tt.input)
 	}

--- a/mail.go
+++ b/mail.go
@@ -132,3 +132,15 @@ func ParseMIMEBody(mailMsg *mail.Message) (*MIMEBody, error) {
 func (m *MIMEBody) GetHeader(name string) string {
 	return DecodeHeader(m.header.Get(name))
 }
+
+// Return AddressList with RFC 2047 encoded encoded names.
+func (m *MIMEBody) AddressList(key string) ([]*mail.Address, error) {
+	ret, err := m.header.AddressList(key)
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range ret {
+		addr.Name = DecodeHeader(addr.Name)
+	}
+	return ret, nil
+}

--- a/mail.go
+++ b/mail.go
@@ -130,5 +130,5 @@ func ParseMIMEBody(mailMsg *mail.Message) (*MIMEBody, error) {
 
 // Process the specified header for RFC 2047 encoded words and return the result
 func (m *MIMEBody) GetHeader(name string) string {
-	return decodeHeader(m.header.Get(name))
+	return DecodeHeader(m.header.Get(name))
 }

--- a/mail_test.go
+++ b/mail_test.go
@@ -184,8 +184,9 @@ func TestParseNestedHeaders(t *testing.T) {
 	assert.Equal(t, mime.Inlines[0].Header().Get("Content-Id"), "<8B8481A2-25CA-4886-9B5A-8EB9115DD064@skynet>", "Inline should have a Content-Id header")
 }
 
-func TestParseEncodedSubject(t *testing.T) {
+func TestParseEncodedSubjectAndAddress(t *testing.T) {
 	// Even non-MIME messages should support encoded-words in headers
+	// Also, encoded addresses should be suppored
 	msg := readMessage("qp-ascii-header.raw")
 	mime, err := ParseMIMEBody(msg)
 	if err != nil {
@@ -200,6 +201,12 @@ func TestParseEncodedSubject(t *testing.T) {
 		t.Fatalf("Failed to parse MIME: %v", err)
 	}
 	assert.Equal(t, mime.GetHeader("Subject"), "MIME UTF8 Test \u00a2 More Text")
+	toAddresses, err := mime.AddressList("To")
+	if err != nil {
+		t.Fatalf("Failed to parse To list: %v", err)
+	}
+	assert.Equal(t, len(toAddresses), 1)
+	assert.Equal(t, toAddresses[0].Name, "Mirosław Marczak")
 }
 
 // readMessage is a test utility function to fetch a mail.Message object.

--- a/test-data/mail/qp-utf8-header.raw
+++ b/test-data/mail/qp-utf8-header.raw
@@ -3,7 +3,7 @@ Date: Fri, 19 Oct 2012 12:22:49 -0700
 From: James Hillyerd <jamehi03@jamehi03lx.noa.com>
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0) Gecko/20121010 Thunderbird/16.0.1
 MIME-Version: 1.0
-To: greg@inbucket.com
+To: =?UTF-8?Q?Miros=C5=82aw_Marczak?= <greg@inbucket.com>
 Subject: =?utf-8?q?MIME_UTF8_Test_=c2=a2?= More Text
 Content-Type: multipart/alternative;
  boundary="------------020203040006070307010003"


### PR DESCRIPTION
Please find the use case below.

Premise 1:
---
Passing the address list retrieved using `(*enmime.MIMEBody).GetHeader` to `net/mail.ParseAddressList` results in the following error for an address like `=?UTF-8?Q?Miros=C5=82aw_Marczak?= <xxx@xxx.pl>`:
```
mail: no angle-addr
```

Premise 2:
---
I want to be able to pretty-print names in address fields just the way I print text.

Conclusion:
---
By exposing enmime.DecodeHeader I can do something like:
```
func printAddresses(msg *mail.Message, key string) {
	list, err := msg.Header.AddressList(key)
	if err == mail.ErrHeaderNotPresent {
		return
	}
	if err != nil {
		glog.Errorf("Error parsing %q list (%q): %v", key, list, err)
		return
	}
	for i, addr := range list {
		fmt.Printf(
			"%s #%d: %s <%s>\n",
			key,
			(i + 1),
			enmime.DecodeHeader(addr.Name),
			addr.Address,
		)
	}
}
```
...and get the best of both worlds.