### PR TITLE
Replace github.com/sloonz/go-qprintable with mime/quotedprintable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.4.2
+  - 1.5
   - tip
 
 install:

--- a/part.go
+++ b/part.go
@@ -8,10 +8,9 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"mime/quotedprintable"
 	"net/textproto"
 	"strings"
-
-	"github.com/sloonz/go-qprintable"
 )
 
 // MIMEPart is the primary interface enmine clients will use.  Each MIMEPart represents
@@ -225,7 +224,7 @@ func decodeSection(encoding string, reader io.Reader) ([]byte, error) {
 
 	switch strings.ToLower(encoding) {
 	case "quoted-printable":
-		decoder = qprintable.NewDecoder(qprintable.WindowsTextEncoding, reader)
+		decoder = quotedprintable.NewReader(reader)
 	case "base64":
 		cleaner := NewBase64Cleaner(reader)
 		decoder = base64.NewDecoder(base64.StdEncoding, cleaner)


### PR DESCRIPTION
Go 1.5 introduces a new package into the standard library,
mime/quotedprintable. Use it instead of a third party library