### PR TITLE
If charset is missing from the mime header look for it in the html meta tag

### DIFF
--- a/charsets.go
+++ b/charsets.go
@@ -27,6 +27,7 @@ var encodings = map[string]struct {
 	"unicode-1-1-utf-8":   {encoding.Nop, "utf-8"},
 	"utf-8":               {encoding.Nop, "utf-8"},
 	"utf8":                {encoding.Nop, "utf-8"},
+	"charset=utf-8":       {encoding.Nop, "utf-8"},
 	"866":                 {charmap.CodePage866, "ibm866"},
 	"cp866":               {charmap.CodePage866, "ibm866"},
 	"csibm866":            {charmap.CodePage866, "ibm866"},

--- a/charsets.go
+++ b/charsets.go
@@ -157,6 +157,7 @@ var encodings = map[string]struct {
 	"iso-8859-1":          {charmap.Windows1252, "windows-1252"},
 	"iso-ir-100":          {charmap.Windows1252, "windows-1252"},
 	"iso8859-1":           {charmap.Windows1252, "windows-1252"},
+	"iso8859_1":           {charmap.Windows1252, "windows-1252"},
 	"iso88591":            {charmap.Windows1252, "windows-1252"},
 	"iso_8859-1":          {charmap.Windows1252, "windows-1252"},
 	"iso_8859-1:1987":     {charmap.Windows1252, "windows-1252"},

--- a/header.go
+++ b/header.go
@@ -336,7 +336,7 @@ func convertText(charset string, encoding string, encTextBytes []byte) (string, 
 		return "", err
 	}
 
-	return ConvertToUTF8String(charset, string(textBytes))
+	return ConvertToUTF8String(charset, textBytes)
 }
 
 func decodeQuotedPrintable(input []byte) ([]byte, error) {

--- a/part.go
+++ b/part.go
@@ -128,6 +128,22 @@ func ParseMIME(reader *bufio.Reader) (MIMEPart, error) {
 	return root, nil
 }
 
+func parseBadContentType(ctype, sep string) string {
+	cp := strings.Split(ctype, sep)
+	mctype := ""
+	for _, p := range cp {
+		if strings.Contains(p, "=") {
+			params := strings.Split(p, "=")
+			if !strings.Contains(mctype, params[0]+"=") {
+				mctype += p + ";"
+			}
+		} else {
+			mctype += p + ";"
+		}
+	}
+	return mctype
+}
+
 // parseParts recursively parses a mime multipart document.
 func parseParts(parent *memMIMEPart, reader io.Reader, boundary string) error {
 	var prevSibling *memMIMEPart
@@ -166,21 +182,18 @@ func parseParts(parent *memMIMEPart, reader io.Reader, boundary string) error {
 		mediatype, mparams, err := mime.ParseMediaType(ctype)
 		if err != nil {
 			// Small hack to remove harmless charset duplicate params
-			cp := strings.Split(ctype, ";")
-			mctype := ""
-			for _, p := range cp {
-				if strings.Contains(p, "=") {
-					params := strings.Split(p, "=")
-					if !strings.Contains(mctype, params[0]+"=") {
-						mctype += p + ";"
-					}
-				} else {
-					mctype += p + ";"
-				}
-			}
+			mctype := parseBadContentType(ctype, ";")
 			mediatype, mparams, err = mime.ParseMediaType(mctype)
 			if err != nil {
-				return err
+				// Some badly formed content-types forget to send a ; between fields
+				mctype := parseBadContentType(ctype, " ")
+				if strings.Contains(mctype, `name=""`) {
+					mctype = strings.Replace(mctype, `name=""`, `name=" "`, -1)
+				}
+				mediatype, mparams, err = mime.ParseMediaType(mctype)
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/part.go
+++ b/part.go
@@ -165,7 +165,22 @@ func parseParts(parent *memMIMEPart, reader io.Reader, boundary string) error {
 		}
 		mediatype, mparams, err := mime.ParseMediaType(ctype)
 		if err != nil {
-			return err
+			// Small hack to remove harmless charset duplicate params
+			cp := strings.Split(ctype, ";")
+			mctype := ""
+			for _, p := range cp {
+				if strings.Contains(p, "charset=") {
+					if !strings.Contains(mctype, "charset=") {
+						mctype += p + ";"
+					}
+				} else {
+					mctype += p + ";"
+				}
+			}
+			mediatype, mparams, err = mime.ParseMediaType(mctype)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Insert ourselves into tree, p is enmime's mime-part

--- a/part.go
+++ b/part.go
@@ -169,8 +169,9 @@ func parseParts(parent *memMIMEPart, reader io.Reader, boundary string) error {
 			cp := strings.Split(ctype, ";")
 			mctype := ""
 			for _, p := range cp {
-				if strings.Contains(p, "charset=") {
-					if !strings.Contains(mctype, "charset=") {
+				if strings.Contains(p, "=") {
+					params := strings.Split(p, "=")
+					if !strings.Contains(mctype, params[0]+"=") {
 						mctype += p + ";"
 					}
 				} else {


### PR DESCRIPTION
Some email are missing a mime header that contains the charset value. In such cases we need to look for the charset inside the html, otherwise we end up with wrongly a encoded html body.

This pull request does a regexp lookup for the charset value in the meta tag (supports both html 4.01 and html 5 charsets).

Also the ConvertToUTF8String function signature has been changed to take in a byte array instead of a string since it seemed wasteful to convert from bytes to string outside and back to bytes again inside ConvertToUTF8String.
