### PR TITLE
Ability to change part data.

### DIFF
--- a/part.go
+++ b/part.go
@@ -20,15 +20,19 @@ import (
 // TODO Content should probably be a reader so that it does not need to be stored in
 // memory.
 type MIMEPart interface {
-	Parent() MIMEPart             // Parent of this part (can be nil)
-	FirstChild() MIMEPart         // First (top most) child of this part
-	NextSibling() MIMEPart        // Next sibling of this part
-	Header() textproto.MIMEHeader // Header as parsed by textproto package
-	ContentType() string          // Content-Type header without parameters
-	Disposition() string          // Content-Disposition header without parameters
-	FileName() string             // File Name from disposition or type header
-	Charset() string              // Content Charset
-	Content() []byte              // Decoded content of this part (can be empty)
+	Parent() MIMEPart               // Parent of this part (can be nil)
+	FirstChild() MIMEPart           // First (top most) child of this part
+	NextSibling() MIMEPart          // Next sibling of this part
+	Header() textproto.MIMEHeader   // Header as parsed by textproto package
+	SetHeader(textproto.MIMEHeader) // Sets the part MIME header
+	ContentType() string            // Content-Type header without parameters
+	SetContentType(string)          // Sets the Content-Type header
+	Disposition() string            // Content-Disposition header without parameters
+	SetDisposition(string)          // Sets the Content-Disposition header
+	FileName() string               // File Name from disposition or type header
+	SetFileName(string)             // Set file name
+	Charset() string                // Content Charset
+	Content() []byte                // Decoded content of this part (can be empty)
 }
 
 // memMIMEPart is an in-memory implementation of the MIMEPart interface.  It will likely
@@ -71,9 +75,20 @@ func (p *memMIMEPart) Header() textproto.MIMEHeader {
 	return p.header
 }
 
+// SetHeader sets a MIME part header.
+func (p *memMIMEPart) SetHeader(header textproto.MIMEHeader) {
+	p.header = header
+}
+
 // Content-Type header without parameters
 func (p *memMIMEPart) ContentType() string {
 	return p.contentType
+}
+
+// SetContentType sets the Content-Type.
+// Example: "image/jpg" or "application/octet-stream"
+func (p *memMIMEPart) SetContentType(contentType string) {
+	p.contentType = contentType
 }
 
 // Content-Disposition header without parameters
@@ -81,9 +96,20 @@ func (p *memMIMEPart) Disposition() string {
 	return p.disposition
 }
 
+// SetDisposition sets the Content-Disposition.
+// Example: "attachment" or "inline"
+func (p *memMIMEPart) SetDisposition(disposition string) {
+	p.disposition = disposition
+}
+
 // File Name from disposition or type header
 func (p *memMIMEPart) FileName() string {
 	return p.fileName
+}
+
+// SetFileName sets the parts file name.
+func (p *memMIMEPart) SetFileName(fileName string) {
+	p.fileName = fileName
 }
 
 // Content charset

--- a/part_test.go
+++ b/part_test.go
@@ -3,6 +3,7 @@ package enmime
 import (
 	"bufio"
 	"fmt"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"testing"
@@ -224,6 +225,26 @@ func TestBadBoundaryTerm(t *testing.T) {
 	assert.Equal(t, "text/html", p.ContentType(), "Second child should have been html")
 	assert.Contains(t, string(p.Content()), "An HTML section", "Second child contains wrong content")
 	assert.Nil(t, p.NextSibling(), "Second child should not have a sibling")
+}
+
+func TestPartSetter(t *testing.T) {
+
+	m := memMIMEPart{}
+
+	h := textproto.MIMEHeader{
+		"Content-Type": {"testType"},
+	}
+	m.SetHeader(h)
+	assert.Equal(t, m.Header(), h)
+
+	m.SetContentType("application/octet-stream")
+	assert.Equal(t, m.ContentType(), "application/octet-stream")
+
+	m.SetDisposition("inline")
+	assert.Equal(t, m.Disposition(), "inline")
+
+	m.SetFileName("somefilename")
+	assert.Equal(t, m.FileName(), "somefilename")
 }
 
 // openPart is a test utility function to open a part as a reader


### PR DESCRIPTION
After parsing an email or mime message, there is often the need to
change some part setting. This is the case for mail clients generating
wrong mime header.

As an example a mime header generated by AppleMail for an (inline)
attachment:

Content-Disposition: inline;
	filename=utf-8''Dog%20with%20o%CC%88a%CC%88u%CC%88.jpg
Content-Type: image/jpeg;
	name*=utf-8''Dog%20with%20o%CC%88a%CC%88u%CC%88.jpg;
	x-unix-mode=0644

The Content-Disposition filename isn't quoted correctly RFC 2231. It
must be filename*= to indicate a quoted value. The Content-Type name is
correct. Parsing this MIME part will generate:

part.FileName() = utf-8''Dog%20with%20o%CC%88a%CC%88u%CC%88.jpg

Setting functions for the MIME part will allow to cleanup these errors.